### PR TITLE
Add MAX indicator to upgrade buttons

### DIFF
--- a/IdleGame/Assets/Scripts/CheatManager.cs
+++ b/IdleGame/Assets/Scripts/CheatManager.cs
@@ -5,19 +5,21 @@ using UnityEngine;
 public class CheatManager : MonoBehaviour
 {
     public GameManager gameManager;
+    public int givePixelPoints = 10;
+    public int givePrestigePoints = 10;
 
     // Update is called once per frame
     void Update()
     {
         if (Input.GetKeyDown(KeyCode.Alpha1))
         {
-            gameManager.currencyManager.IncrementPixelPoints();
+            gameManager.currencyManager.IncrementPixelPoints(givePixelPoints);
             gameManager.uiManager.UpdateWorkerUpgradeButtons();
         }
         
         if (Input.GetKeyDown(KeyCode.Alpha2))
         {
-            gameManager.currencyManager.IncrementPrestigePoints();
+            gameManager.currencyManager.IncrementPrestigePoints(givePrestigePoints);
             gameManager.uiManager.UpdateWorkerUpgradeButtons();
         }
     }

--- a/IdleGame/Assets/Scripts/UIManager.cs
+++ b/IdleGame/Assets/Scripts/UIManager.cs
@@ -43,19 +43,19 @@ public class UIManager : MonoBehaviour
             "prestigeAutomationTooltip",  // 0 Tooltip Name
             "Buy to enable Automation", // 1 Can Afford
             "Buy to enable Automation\nYou need more Prestige Points to buy this", // 2 Can NOT Afford
-            "Automation Purchased", // 3 Purchased
+            "Automation already purchased", // 3 Purchased
         },
         { // 1 Recycle Texts
             "prestigeRecycleTooltip",  // 0 Tooltip Name
             "Buy to enable Recycle", // 1 Can Afford
             "Buy to enable Recycle\nYou need more Prestige Points to buy this", // 2 Can NOT Afford
-            "Recycle Purchased", // 3 Purchased
+            "Recycle already purchased", // 3 Purchased
         },
         { // 2 Custom Start and End Texts
             "prestigeCustomStartAndEndTooltip",  // 0 Tooltip Name
             "Buy to enable custom start and end colours on game restart", // 1 Can Afford
             "Buy to enable custom start and end colours on game restart\nYou need more Prestige Points to buy this", // 2 Can NOT Afford
-            "Custom Colors Purchased", // 3 Purchased
+            "Custom Colors already purchased", // 3 Purchased
         },
         { // 3 Increase Pixel Points Texts
             "prestigeIncreasePixelPointsTooltip",  // 0 Tooltip Name
@@ -459,7 +459,7 @@ public class UIManager : MonoBehaviour
             UpdateTooltipText(prestigeButtonTooltipTexts[2, 0], pm.prestigeCustomStartAndEndButton, prestigeButtonTooltipTexts[2, 2]);
         }
 
-        // IncreasePixelPoints Button - NOT IMPLEMENTED
+        // IncreasePixelPoints Button
         if (gameManager.currencyManager.prestigePoints >= pm.prestigeIncreasePixelPointsCost)
         {
             pm.prestigeIncreasePixelPointsButton.SetEnabled(true);
@@ -478,9 +478,13 @@ public class UIManager : MonoBehaviour
         {
             WorkerUpgrade wupg = worker.workerUpgrade;
             wupg.automationButton.Q<Label>().text = ""; //wupg.buttonStatuses[wupg.automationButton] == WorkerUpgrade.UpgradeStatus.Purchased ? "" : "Cost: " + wupg.automationCost.ToString();
-            wupg.productionMultiplierButton.Q<Label>().text = "Level: " + wupg.productionLevel.ToString() + "\nCost: " + wupg.ProductionMultiplierCost().ToString();
             wupg.autoTickSpeedMuiltiplierButton.Q<Label>().text = "Level: " + wupg.autoTickSpeedLevel.ToString() + "\nCost: " + wupg.AutoTickSpeedMultiplierCost().ToString();
             wupg.recycleButton.Q<Label>().text = "Level: " + wupg.recycleLevel.ToString() + "\nCost: " + wupg.RecycleMultiplierCost().ToString();
+
+            if (wupg.productionLevel < 10)
+                wupg.productionMultiplierButton.Q<Label>().text = "Level: " + wupg.productionLevel.ToString() + "\nCost: " + wupg.ProductionMultiplierCost().ToString();
+            else
+                wupg.productionMultiplierButton.Q<Label>().text = "Level: MAX";
         }
     }
 

--- a/IdleGame/Assets/Scripts/WorkerUpgrade.cs
+++ b/IdleGame/Assets/Scripts/WorkerUpgrade.cs
@@ -14,7 +14,7 @@ public class WorkerUpgrade : MonoBehaviour
     public Button productionMultiplierButton;
     public int productionLevel = 1;
     public float ProductionMultiplier() => Mathf.Min(10, productionLevel); // % of the bar to fill when manually clicking (multiplied in Worker by starting amount (10))
-    public int ProductionMultiplierCost() => (int)Mathf.Pow(2, productionLevel - 1);
+    public int ProductionMultiplierCost() => productionLevel < 10 ? (int)Mathf.Pow(2, productionLevel - 1) : 0;
 
     [Header("Automation Unlock")]
     public Button automationButton; // enabled automation
@@ -25,7 +25,7 @@ public class WorkerUpgrade : MonoBehaviour
     [Header("Automation Upgrades")]
     public Button autoTickSpeedMuiltiplierButton; // speed of tick 
     public int autoTickSpeedLevel = 1;
-    public float AutoTickSpeedMultiplier() => Mathf.Max(0.1f, 1 - autoTickSpeedLevel * 0.1f);
+    public float AutoTickSpeedMultiplier() =>1f / autoTickSpeedLevel;
     public int AutoTickSpeedMultiplierCost() => (int) Mathf.Pow(2, autoTickSpeedLevel - 1);
 
     [Header("Recycle Upgrades")]
@@ -103,7 +103,7 @@ public class WorkerUpgrade : MonoBehaviour
 
     public void ProductionMultiplierButton()
     {
-        if (gameManager.currencyManager.pixelPoints >= ProductionMultiplierCost())
+        if (productionLevel < 10 && gameManager.currencyManager.pixelPoints >= ProductionMultiplierCost())
         {
             gameManager.currencyManager.PurchaseWithPixelPoints(ProductionMultiplierCost());
             productionLevel += 1;


### PR DESCRIPTION
Add MAX indicator to production button. Max is set to 10 which is 100% fill. No other buttons have a maximum.. Tick speed calc changed to 1/level.
![image](https://user-images.githubusercontent.com/46137966/142274277-4575cbd3-3d6a-46b9-a8a7-c3dd92000e2f.png)
